### PR TITLE
Add loading state and live updates for responses

### DIFF
--- a/background.js
+++ b/background.js
@@ -37,19 +37,38 @@ api.contextMenus.onClicked.addListener(async (info, tab) => {
     return;
   }
 
+  let baseResult;
+
   try {
     const prompt = await buildPrompt(info, tab);
-    const answer = await callModel(prompt, settings);
-    await persistResult({
+    baseResult = {
       source: info.menuItemId === 'ai-selection' ? 'selection' : 'page',
       question: prompt,
-      answer,
       url: tab.url || '',
       createdAt: Date.now()
-    });
+    };
+
+    await persistResult({ ...baseResult, status: 'loading', answer: '' });
     await api.tabs.create({ url: api.runtime.getURL('response.html') });
+
+    const answer = await callModel(prompt, settings);
+
+    await persistResult({
+      ...baseResult,
+      status: 'complete',
+      answer,
+      completedAt: Date.now()
+    });
   } catch (error) {
     log('Error calling model', error);
+    if (baseResult) {
+      await persistResult({
+        ...baseResult,
+        status: 'error',
+        answer: error?.message || String(error),
+        completedAt: Date.now()
+      });
+    }
     api.notifications.create({
       type: 'basic',
       iconUrl: 'icons/icon-48.png',

--- a/response.css
+++ b/response.css
@@ -91,3 +91,45 @@ button {
 .hidden {
   display: none;
 }
+
+.loading {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: #d1d5db;
+}
+
+.spinner {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #93c5fd;
+  animation: spin 1s linear infinite;
+}
+
+.loading-text {
+  margin: 0;
+  font-weight: 600;
+}
+
+.partial-label {
+  margin: 8px 0 0 0;
+  color: #93c5fd;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+}
+
+.error-box {
+  background: rgba(239, 68, 68, 0.15);
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  border-radius: 6px;
+  padding: 12px;
+  color: #fecdd3;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/response.js
+++ b/response.js
@@ -146,11 +146,47 @@ function render(result) {
     <div><strong>Source:</strong> ${result.source}</div>
     <div><strong>URL:</strong> ${result.url || 'N/A'}</div>
     <div><strong>Asked:</strong> ${formatDate(result.createdAt)}</div>
+    ${result.completedAt ? `<div><strong>Updated:</strong> ${formatDate(result.completedAt)}</div>` : ''}
   `;
 
   const { visibleNodes, reasoningNodes } = parseAnswerContent(result.answer);
 
   answer.textContent = '';
+
+  const status = result.status || 'complete';
+
+  if (status === 'loading') {
+    const loadingContainer = document.createElement('div');
+    loadingContainer.className = 'loading';
+
+    const spinner = document.createElement('div');
+    spinner.className = 'spinner';
+    loadingContainer.appendChild(spinner);
+
+    const loadingText = document.createElement('p');
+    loadingText.className = 'loading-text';
+    loadingText.textContent = 'Waiting for the model to respond...';
+    loadingContainer.appendChild(loadingText);
+
+    answer.appendChild(loadingContainer);
+
+    if (result.answer) {
+      const partialLabel = document.createElement('p');
+      partialLabel.className = 'partial-label';
+      partialLabel.textContent = 'Partial response';
+      answer.appendChild(partialLabel);
+    } else {
+      return;
+    }
+  }
+
+  if (status === 'error') {
+    const errorBox = document.createElement('div');
+    errorBox.className = 'error-box';
+    errorBox.textContent = result.answer || 'An error occurred while fetching the response.';
+    answer.appendChild(errorBox);
+    return;
+  }
 
   const visibleSection = document.createElement('div');
   visibleSection.className = 'answer-visible';
@@ -196,5 +232,10 @@ function load() {
 
 (function init() {
   $('refresh').addEventListener('click', load);
+  api.storage.onChanged.addListener((changes, area) => {
+    if (area === 'local' && changes.lastResult) {
+      render(changes.lastResult.newValue);
+    }
+  });
   load();
 })();


### PR DESCRIPTION
## Summary
- open the response page immediately when a request begins and persist request status
- surface loading, partial, and error states in the response view with new styling
- refresh the response view automatically as stored results update

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a75125a44832d813026c58590e7df)