### PR TITLE
Clean up merge artifacts in background and response handling

### DIFF
--- a/background.js
+++ b/background.js
@@ -62,8 +62,6 @@ api.contextMenus.onClicked.addListener(async (info, tab) => {
     return;
   }
 
-  let baseResult;
-
   try {
     const prompt = await buildPrompt(info, tab);
     const messages = [
@@ -82,25 +80,8 @@ api.contextMenus.onClicked.addListener(async (info, tab) => {
     await persistConversation(conversation);
     broadcastConversation(conversation);
     await api.tabs.create({ url: api.runtime.getURL('response.html') });
-
-    const answer = await callModel(prompt, settings);
-
-    await persistResult({
-      ...baseResult,
-      status: 'complete',
-      answer,
-      completedAt: Date.now()
-    });
   } catch (error) {
     log('Error calling model', error);
-    if (baseResult) {
-      await persistResult({
-        ...baseResult,
-        status: 'error',
-        answer: error?.message || String(error),
-        completedAt: Date.now()
-      });
-    }
     api.notifications.create({
       type: 'basic',
       iconUrl: 'icons/icon-48.png',

--- a/response.js
+++ b/response.js
@@ -213,41 +213,6 @@ function buildAssistantContent(answer) {
 
   const { visibleNodes, reasoningNodes } = parseAnswerContent(answer);
 
-  const status = result.status || 'complete';
-
-  if (status === 'loading') {
-    const loadingContainer = document.createElement('div');
-    loadingContainer.className = 'loading';
-
-    const spinner = document.createElement('div');
-    spinner.className = 'spinner';
-    loadingContainer.appendChild(spinner);
-
-    const loadingText = document.createElement('p');
-    loadingText.className = 'loading-text';
-    loadingText.textContent = 'Waiting for the model to respond...';
-    loadingContainer.appendChild(loadingText);
-
-    answer.appendChild(loadingContainer);
-
-    if (result.answer) {
-      const partialLabel = document.createElement('p');
-      partialLabel.className = 'partial-label';
-      partialLabel.textContent = 'Partial response';
-      answer.appendChild(partialLabel);
-    } else {
-      return;
-    }
-  }
-
-  if (status === 'error') {
-    const errorBox = document.createElement('div');
-    errorBox.className = 'error-box';
-    errorBox.textContent = result.answer || 'An error occurred while fetching the response.';
-    answer.appendChild(errorBox);
-    return;
-  }
-
   const visibleSection = document.createElement('div');
   visibleSection.className = 'answer-visible';
   visibleNodes.forEach((node) => visibleSection.appendChild(document.importNode(node, true)));


### PR DESCRIPTION
## Summary
- remove duplicate request/persistence logic introduced by merge artifact in the background listener
- simplify assistant rendering logic to drop references to undefined result objects

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a7c82d0bc832d9280d77f94564c01)