### PR TITLE
Add display text labels for conversation prompts

### DIFF
--- a/response.js
+++ b/response.js
@@ -274,7 +274,7 @@ function renderConversation(data) {
       if (msg.role === 'assistant') {
         body.appendChild(buildAssistantContent(msg.content));
       } else {
-        body.textContent = msg.content;
+        body.textContent = msg.displayText || msg.content;
       }
 
       messageEl.appendChild(body);


### PR DESCRIPTION
## Summary
- add display text labels to initial context-menu prompts while keeping full prompt content for the model
- render stored user messages using their display text in the response view
- ensure follow-up prompts are stored with display text and model calls receive only the full content

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a7eea2a54832da6eb7ed53cf6a9c6)