### PR TITLE
Add summarize action for empty conversation state

### DIFF
--- a/response.css
+++ b/response.css
@@ -194,6 +194,26 @@ button[disabled] {
   text-align: left;
 }
 
+.empty-state {
+  border: 1px dashed rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 10px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.empty-state h2 {
+  margin: 0;
+}
+
+.empty-actions {
+  display: flex;
+  gap: 10px;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;

--- a/response.js
+++ b/response.js
@@ -275,7 +275,11 @@ function renderConversation(data) {
   renderMeta(data);
   setFollowUpEnabled(Boolean(data));
 
-  if (!data) return;
+  if (!data) {
+    renderEmptyConversation();
+    showStatus('');
+    return;
+  }
 
   const messages = data.messages || [];
   messages
@@ -315,6 +319,34 @@ function renderConversation(data) {
   } else {
     showStatus('');
   }
+}
+
+function renderEmptyConversation() {
+  const container = $('conversation');
+  if (!container) return;
+
+  const empty = document.createElement('article');
+  empty.className = 'empty-state';
+
+  const title = document.createElement('h2');
+  title.textContent = 'Ask about this page';
+  empty.appendChild(title);
+
+  const body = document.createElement('p');
+  body.textContent = 'Start by summarizing the page you are viewing.';
+  empty.appendChild(body);
+
+  const actions = document.createElement('div');
+  actions.className = 'empty-actions';
+
+  const summarizeBtn = document.createElement('button');
+  summarizeBtn.id = 'summarize';
+  summarizeBtn.textContent = 'Summarize';
+  summarizeBtn.addEventListener('click', handleSummarizePage);
+  actions.appendChild(summarizeBtn);
+
+  empty.appendChild(actions);
+  container.appendChild(empty);
 }
 
 function appendUserMessage(prompt) {
@@ -551,6 +583,16 @@ function handleFollowUp(evt) {
   $('prompt').value = '';
   appendUserMessage(prompt);
   port?.postMessage({ type: 'followup', prompt });
+}
+
+function handleSummarizePage(evt) {
+  evt?.preventDefault?.();
+  if (sending) return;
+
+  setFollowUpEnabled(false);
+  setSendingState(true);
+  showStatus('Summarizing page...');
+  port?.postMessage({ type: 'summarize-page' });
 }
 
 function initPort() {


### PR DESCRIPTION
## Summary
- show a placeholder with an Ask about this page prompt and Summarize button when no conversation exists
- wire the Summarize button to request a page summary and re-enable the conversation view
- add background support to create, persist, and broadcast a new summary conversation for the active tab

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a89720950832db4287fc30fa2c683)