### PR TITLE
Remove new-tab results and use sidebar only

### DIFF
--- a/background.js
+++ b/background.js
@@ -5,7 +5,7 @@ const DEFAULT_SETTINGS = {
   apiKey: '',
   baseUrl: 'https://api.openai.com/v1/chat/completions',
   model: 'gpt-4o-mini',
-  responseTarget: 'tab',
+  responseTarget: 'sidebar',
   temperature: 0.3,
   maxTokens: 4096
 };
@@ -13,7 +13,6 @@ const DEFAULT_SETTINGS = {
 const SYSTEM_PROMPT = 'You are a helpful assistant for summarizing web content.';
 const STORAGE_KEY = 'conversation';
 const responsePorts = new Set();
-const RESPONSE_TARGETS = ['tab', 'sidebar', 'both'];
 
 function getDefaultBaseUrl(provider) {
   return provider === 'anthropic'
@@ -24,9 +23,7 @@ function getDefaultBaseUrl(provider) {
 function normalizeSettings(settings) {
   const provider = settings.provider || DEFAULT_SETTINGS.provider;
   let baseUrl = settings.baseUrl;
-  const responseTarget = RESPONSE_TARGETS.includes(settings.responseTarget)
-    ? settings.responseTarget
-    : DEFAULT_SETTINGS.responseTarget;
+  const responseTarget = DEFAULT_SETTINGS.responseTarget;
 
   if (!baseUrl || (provider === 'anthropic' && baseUrl === DEFAULT_SETTINGS.baseUrl)) {
     baseUrl = getDefaultBaseUrl(provider);
@@ -58,15 +55,10 @@ function openSidebar() {
   }
 }
 
-function openResponseViews(target) {
-  const shouldOpenTab = target === 'tab' || target === 'both';
-  const shouldOpenSidebar = target === 'sidebar' || target === 'both';
-
+function openResponseViews() {
   return {
-    tabPromise: shouldOpenTab
-      ? api.tabs.create({ url: api.runtime.getURL('response.html') })
-      : Promise.resolve(),
-    sidebarPromise: shouldOpenSidebar ? openSidebar() : Promise.resolve()
+    tabPromise: Promise.resolve(),
+    sidebarPromise: openSidebar(),
   };
 }
 
@@ -100,7 +92,7 @@ api.contextMenus.onClicked.addListener(async (info, tab) => {
       { role: 'system', content: SYSTEM_PROMPT },
       { role: 'user', content: prompt.content, displayText: prompt.displayText }
     ];
-    const { tabPromise: responseTabPromise, sidebarPromise } = openResponseViews(settings.responseTarget);
+    const { tabPromise: responseTabPromise, sidebarPromise } = openResponseViews();
 
     const initialConversation = buildConversation({
       source: info.menuItemId === 'ai-selection' ? 'selection' : 'page',

--- a/popup.html
+++ b/popup.html
@@ -29,14 +29,6 @@
         Model name
         <input id="model" type="text" placeholder="gpt-4o-mini or claude-3-haiku-20240307" />
       </label>
-      <label>
-        Response target
-        <select id="responseTarget">
-          <option value="tab">Open in new tab</option>
-          <option value="sidebar">Open in sidebar</option>
-          <option value="both">Open in both</option>
-        </select>
-      </label>
       <div class="grid">
         <label>
           Temperature
@@ -55,7 +47,7 @@
       <ol>
         <li>Select text on any page and choose <strong>Ask AI about selection</strong> from the context menu.</li>
         <li>Right-click anywhere and choose <strong>Ask AI about this page</strong> for a summary and takeaways.</li>
-        <li>Results open in your chosen target (tab, sidebar, or both) with your latest answer. Update settings here anytime.</li>
+        <li>Results open in the sidebar with your latest answer. Update settings here anytime.</li>
       </ol>
     </section>
   </main>

--- a/popup.js
+++ b/popup.js
@@ -4,7 +4,6 @@ const defaults = {
   apiKey: '',
   baseUrl: 'https://api.openai.com/v1/chat/completions',
   model: 'gpt-4o-mini',
-  responseTarget: 'tab',
   temperature: 0.3,
   maxTokens: 4096
 };
@@ -60,7 +59,6 @@ async function loadSettings() {
     $('apiKey').value = settings.apiKey || '';
     $('baseUrl').value = settings.baseUrl;
     $('model').value = settings.model;
-    $('responseTarget').value = settings.responseTarget || defaults.responseTarget;
     $('temperature').value = settings.temperature;
     $('maxTokens').value = settings.maxTokens;
 
@@ -94,7 +92,6 @@ async function saveSettings(evt) {
       apiKey: $('apiKey').value.trim(),
       baseUrl: $('baseUrl').value.trim(),
       model: $('model').value.trim(),
-      responseTarget: $('responseTarget').value,
       temperature: parseNumberInput('temperature', existing.temperature),
       maxTokens: parseNumberInput('maxTokens', existing.maxTokens)
     };


### PR DESCRIPTION
## Summary
- always open AI responses in the sidebar and drop tab/both handling
- simplify settings UI by removing the response target selector and updating usage text

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a8c6fc86c832d8be6ce019003422c)